### PR TITLE
Fixing webClientID and using idToken instead of oAuthToken 

### DIFF
--- a/cordova/cordova_g_plus.js
+++ b/cordova/cordova_g_plus.js
@@ -15,7 +15,7 @@ Meteor.cordova_g_plus = function(request, callback) {
      */
     window.plugins.googleplus.login({
             offline: true,
-            webClientId: request.clientId
+            webClientId: request.webClientId
         },
         function(response) {
             request.email = response.email;

--- a/cordova/cordova_g_plus.js
+++ b/cordova/cordova_g_plus.js
@@ -28,8 +28,8 @@ Meteor.cordova_g_plus = function(request, callback) {
             });
         },
         function(error) {
-            alert(error);
             if (callback && (typeof callback == "function")) callback(error);
+            else alert(error);
         }
     );
 };

--- a/cordova/cordova_g_plus.js
+++ b/cordova/cordova_g_plus.js
@@ -13,13 +13,13 @@ Meteor.cordova_g_plus = function(request, callback) {
      * @param {Array} request.profile Is an array of profile properties required, eg. `["email", "email_verified", "gender"]`
      * @param {Function} callback `callback` function can have one argument `error` which will be containing the details of error if any
      */
-
     window.plugins.googleplus.login({
-            offline: true
+            offline: true,
+            webClientId: request.clientId
         },
         function(response) {
             request.email = response.email;
-            request.oAuthToken = response.oauthToken;
+            request.idToken = response.idToken;
             request.sub = response.userId;
 
             Accounts.callLoginMethod({ // call cordova_g_plus SignIn handler @ server
@@ -28,8 +28,8 @@ Meteor.cordova_g_plus = function(request, callback) {
             });
         },
         function(error) {
+            alert(error);
             if (callback && (typeof callback == "function")) callback(error);
-            else alert(error);
         }
     );
 };

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  "cordova-plugin-googleplus": "https://github.com/EddyVerbruggen/cordova-plugin-googleplus.git#3ae99ea5d24619949613b87cdcb01b407199c253"
+  "cordova-plugin-googleplus": "https://github.com/EddyVerbruggen/cordova-plugin-googleplus.git#ad47b55a5337cc5064bea4f74da414f2fde6da2f"
 });
 
 Package.onUse(function(api) {

--- a/server/cordova_g_plus.js
+++ b/server/cordova_g_plus.js
@@ -6,6 +6,7 @@ Accounts.registerLoginHandler(function(req) { // cordova_g_plus SignIn handler
         cordova_g_plus: Boolean,
         email: String,
         idToken: String,
+        webClientId: String,
         profile: Match.Any,
         sub: String
     });

--- a/server/cordova_g_plus.js
+++ b/server/cordova_g_plus.js
@@ -5,7 +5,7 @@ Accounts.registerLoginHandler(function(req) { // cordova_g_plus SignIn handler
     check(req, {
         cordova_g_plus: Boolean,
         email: String,
-        oAuthToken: String,
+        idToken: String,
         profile: Match.Any,
         sub: String
     });
@@ -17,13 +17,12 @@ Accounts.registerLoginHandler(function(req) { // cordova_g_plus SignIn handler
         userId = null;
 
     if (!user) {
-        var res = Meteor.http.get("https://www.googleapis.com/oauth2/v3/userinfo", {
+        var res = Meteor.http.get("https://www.googleapis.com/oauth2/v3/tokeninfo", {
             headers: {
                 "User-Agent": "Meteor/1.0"
             },
-
             params: {
-                access_token: req.oAuthToken
+                id_token: req.idToken
             }
         });
 
@@ -32,7 +31,7 @@ Accounts.registerLoginHandler(function(req) { // cordova_g_plus SignIn handler
             if ( /* req.email == res.data.email && */ req.sub == res.data.sub) {
                 var googleResponse = _.pick(res.data, "email", "email_verified", "family_name", "gender", "given_name", "locale", "name", "picture", "profile", "sub");
 
-                googleResponse["accessToken"] = req.oAuthToken;
+                googleResponse["idToken"] = req.idToken;
                 googleResponse["id"] = req.sub;
 
                 if (typeof(googleResponse["email"]) == "undefined") {


### PR DESCRIPTION
Hi there,

I finished doing https://github.com/sujith3g/meteor-cordova-google-plus/issues/9
And I fixed a bug where webClientID was not taken into account and thus google doesn't send back an oAuthToken or any other server-token.

This breaks API, as you now have to pass the Client ID to the login function call, like this:

``` coffeescript
if Meteor.isCordova
  Meteor.cordova_g_plus {
    cordova_g_plus: true
    webClientId: '9192134983-N2ktrCTzkyqN16ubfPo6UsJelT8zTx-.apps.googleusercontent.com'
    profile: [
      'email'
      'email_verified'
      'gender'
      'locale'
      'name'
      'picture'
    ]
  }, (error) ->
    alert 'error! ' + error if error?
    return
```

All there is needed to be done is updating the readme on the example, but this should work great (I'm using it right now and pulled my code from a production app)
